### PR TITLE
Update promotion criteria document

### DIFF
--- a/promotion.html
+++ b/promotion.html
@@ -41,18 +41,18 @@
       </h4>
       <ol>
         <li >
-          <p ><span>Version 1.0</span></p>
+          <p ><span>Version >= 1.0</span></p>
         </li>
         <li >
           <p >
-            <span>Good unit test coverage measured by community (e.g. 100% or 75% of what’s important) </span></p>
+            <span>Good unit test coverage measured by community (e.g. 100% or 75% of what’s important)</span></p>
         </li>
         <ol>
           <li >
-            <p ><span>uses travis</span></p>
+            <p ><span>uses CI (Travis-CI)</span></p>
           </li>
           <li >
-            <p ><span>uses coveralls or simplecov</span></p>
+            <p ><span>uses Coverage tool (coveralls or simplecov)</span></p>
           </li>
         </ol>
         <li >
@@ -60,23 +60,20 @@
         </li>
         <ol>
           <li >
-            <p ><span>README </span></p>
+            <p ><span>LICENSE file, Apache 2 (or compatible)</span></p>
+          </li>
+          <li >
+            <p ><span>README.md</span></p>
           </li>
           <ol>
             <li >
               <p ><span>Statement of purpose</span></p>
             </li>
             <li >
-              <p ><span>Explicitly states whether there is a dependency on Hydra</span></p>
+              <p ><span>Basic install steps</span></p>
             </li>
             <li >
-              <p ><span>Lists all third-party dependencies</span></p>
-            </li>
-            <li >
-              <p ><span>Basic install </span></p>
-            </li>
-            <li >
-              <p ><span>List experimental features</span></p>
+              <p ><span>Identify any volatile/experimental features</span></p>
             </li>
           </ol>
           <li >
@@ -86,14 +83,14 @@
             <p ><span>How/Who to contact for help -&gt; push out to all gems like CONTRIBUTING.md</span></p>
           </li>
           <li >
-            <p ><span>Known Issues documented on issues tab</span></p>
+            <p ><span>Known issues documented in github Issues tickets (not just listed in text)</span></p>
           </li>
           <li >
-            <p ><span>Tutorial / walkthrough</span></p>
+            <p ><span>Tutorial / Walkthrough / Example usage</span></p>
           </li>
         </ol>
         <li >
-          <p ><span>Must have any TODO items in documents addressed and removed</span></p>
+          <p ><span>Resolve TODO items in documents and remove them</span></p>
         </li>
         <li >
           <p ><span>Community use by three or more institutions</span></p>
@@ -107,11 +104,11 @@
         </li>
         <ol>
           <li >
-            <p ><span>Compatability can be specified in the gemspec</span></p>
+            <p ><span>Compatability can be specified in the gemspec(s) or verified via CI matrix</span></p>
           </li>
         </ol>
         <li >
-          <p ><span>All Contributors should have Hydra CLA - Apache compatible license [Note for steering committee: what about non-Hydra contributions for gems that don’t require Hydra?]</span>
+          <p ><span>All Contributors should have signed Hydra Contibutor License Agreement (CLA)</span>
           </p>
         </li>
         <li >
@@ -125,14 +122,14 @@
       </h4>
       <ol>
         <li >
-          <p ><span>At each Hydra partners meeting, gems are reviewed for promotion / graveyard</span></p>
+          <p ><span>As needed or requested, Gems are reviewed for promotion / graveyard</span></p>
         </li>
         <ol>
           <li >
-            <p ><span>Items up for promotion will have a breakout group for code review</span></p>
+            <p ><span>A small group should code review the candidates</span></p>
           </li>
           <li >
-            <p ><span>Group of contributors commit to upgrade path</span></p>
+            <p ><span>Group of contributors commits to upgrade path</span></p>
           </li>
           <li >
             <p ><span>Goal to limit movement from ProjectHydra to graveyard (Path to graveyard should be from Labs)</span>
@@ -145,7 +142,6 @@
       </ol>
       <p><strong style="font-weight: normal;">&nbsp;</strong></p>
       <h4>
-
         <p ><span>Questioning Authority as the example todo:</span></p>
       </h4>
       <ol>
@@ -191,21 +187,18 @@
           </li>
         </ol>
         <li >
-          <p ><span>Test on Rails 3 and add to note on compatibility </span></p>
+          <p ><span>Test on Rails 3 and add to note on compatibility</span></p>
         </li>
         <li >
-          <p ><span>Add to Readme Rails 4 on compatibility </span></p>
+          <p ><span>Add to Readme Rails 4 on compatibility</span></p>
         </li>
       </ol>
   </div>
   </section>
   <aside id="sidebar">
-
-
   </aside>
 </div>
 </div>
-
 
 </body>
 </html>


### PR DESCRIPTION
- `>= v1.0`, for obvious reasons
- Emphasize purpose (coverage or CI), not tech
- LICENSE file gets its own bullet point
- "Hydra" is not a thing you can be dependent on. What was meant?
  hydra-head? Also, it doesn't matter for README to document this.  It is part of the _formal_ dependencies.
- Listing _all_ 3rd party dependencies is unreasonable and particularly
  unhelpful for README to attempt.  "I am dependent on libc, ruby
  kernel, TCP/IP, SSH...".  The point is to avoid creating projecthydra
  repos that are just wrappers around 3rd party code when that code is
  domain-specific enough to otherwise be a proper projecthydra (or labs) repo.
  This is subjective and complex enough that it is not easily communicated
  in a bullet point in this list about a README file.
